### PR TITLE
Relax pandas version pin to support 2.2.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ orjson
 datetime
 #numpy=1.26.4
 xarray
-pandas==2.2.0
+pandas~=2.2.0
 covjson-pydantic
 conflator


### PR DESCRIPTION
Is there a reason for the strict pin? If not, relaxing it would make installing this package a lot easier. If this PR sounds good and you have the time, I'd appreciate merging it and releasing it before the holidays - thanks :)